### PR TITLE
Create ColorContent

### DIFF
--- a/Sinopia/Templates/ColorContent
+++ b/Sinopia/Templates/ColorContent
@@ -1,0 +1,24 @@
+<https://api.stage.sinopia.io/resource/pcc:bf2:ColorContent> <http://sinopia.io/vocabulary/hasResourceTemplate> "sinopia:template:resource";
+    a <http://sinopia.io/vocabulary/ResourceTemplate>;
+    <http://sinopia.io/vocabulary/hasResourceId> "pcc:bf2:ColorContent"@en;
+    <http://sinopia.io/vocabulary/hasClass> <http://id.loc.gov/ontologies/bibframe/ColorContent>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Color Content"@en;
+    <http://sinopia.io/vocabulary/hasAuthor> "PCC"@en;
+    <http://sinopia.io/vocabulary/hasDate> "2022-08-24"@en;
+    <http://sinopia.io/vocabulary/hasResourceAttribute> <http://sinopia.io/vocabulary/resourceAttribute/suppressible>;
+    <http://sinopia.io/vocabulary/hasPropertyTemplate> _:b4.
+<http://www.w3.org/2000/01/rdf-schema#label> <http://www.w3.org/2000/01/rdf-schema#label> "label"@en.
+<http://sinopia.io/vocabulary/resourceAttribute/suppressible> <http://www.w3.org/2000/01/rdf-schema#label> "suppressible".
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>;
+    <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5.
+_:b5 a <http://sinopia.io/vocabulary/PropertyTemplate>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Color Content"@en;
+    <http://sinopia.io/vocabulary/hasPropertyUri> <http://www.w3.org/2000/01/rdf-schema#label>;
+    <http://sinopia.io/vocabulary/hasPropertyAttribute> <http://sinopia.io/vocabulary/propertyAttribute/repeatable>;
+    <http://sinopia.io/vocabulary/hasPropertyType> <http://sinopia.io/vocabulary/propertyType/uri>;
+    <http://sinopia.io/vocabulary/hasLookupAttributes> _:b6.
+<http://sinopia.io/vocabulary/propertyAttribute/repeatable> <http://www.w3.org/2000/01/rdf-schema#label> "repeatable".
+<http://sinopia.io/vocabulary/propertyType/uri> <http://www.w3.org/2000/01/rdf-schema#label> "uri or lookup".
+_:b6 a <http://sinopia.io/vocabulary/LookupPropertyTemplate>;
+    <http://sinopia.io/vocabulary/hasAuthority> <https://id.loc.gov/vocabulary/mcolor>.
+<https://id.loc.gov/vocabulary/mcolor> <http://www.w3.org/2000/01/rdf-schema#label> "color".


### PR DESCRIPTION
Subtemplate for use with a bf:Work template to indicate color content using the id.loc.gov Color Content vocabulary as a dropdown